### PR TITLE
Add Sample App To Migrate ABS to SPE

### DIFF
--- a/Samples/migrate-abs-to-spe/AzureBlobManager.cs
+++ b/Samples/migrate-abs-to-spe/AzureBlobManager.cs
@@ -1,0 +1,78 @@
+﻿using Azure.Storage.Blobs;
+
+namespace MigrateABStoSPE
+{
+    public class AzureBlobManager
+    {
+        string _containerLevelSASUrl;
+        BlobContainerClient _containerClient;
+
+        public AzureBlobManager(string containerLevelSASUrl)
+        {
+            _containerLevelSASUrl = containerLevelSASUrl;
+            _containerClient = new BlobContainerClient(new Uri(_containerLevelSASUrl));
+        }
+
+        /// <summary>
+        /// Gets the name of the Azure Blob Storage container.
+        /// </summary>
+        /// <returns>The name of the container.</returns>
+        public string GetContainerName()
+        {
+            return _containerClient.Name;
+        }
+
+        /// <summary>
+        /// Lists all the blobs in the Azure Blob Storage container asynchronously.
+        /// </summary>
+        /// <returns>An enumerable collection of blob names or null.</returns>
+        public async Task<IEnumerable<string>?> ListBlobsAsync()
+        {
+            try
+            {
+                var blobs = new List<string>();
+                await foreach (var blobItem in _containerClient.GetBlobsAsync())
+                {
+                    blobs.Add(blobItem.Name);
+                }
+                return blobs;
+            }
+            catch (Exception ex)
+            {
+                Utility.ConsoleWriteWithColor($"An error occurred while listing blobs: {ex.Message}", ConsoleColor.Red);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Downloads the stream of a blob from Azure Blob Storage.
+        /// </summary>
+        /// <param name="blobName">The name of the blob to download.</param>
+        /// <returns>The stream containing the downloaded blob data or null.</returns>
+        public async Task<Stream> DownloadBlobStreamAsync(string blobName)
+        {
+            try
+            {
+                BlobClient blobClient = _containerClient.GetBlobClient(blobName);
+
+                MemoryStream memoryStream = new MemoryStream();
+                await blobClient.DownloadToAsync(memoryStream);
+                memoryStream.Position = 0; // Reset the stream position to the beginning
+                return memoryStream;
+            }
+            catch (Exception ex)
+            {
+                string message = ex.Message;
+                int index = message.IndexOf("RequestId");
+                if (index != -1)
+                {
+                    message = message.Substring(0, index);
+                }
+
+                Utility.ConsoleWriteWithColor($"An error occurred while downloading blob: {message}", ConsoleColor.Red);
+
+                throw ex;
+            }
+        }
+    }
+}

--- a/Samples/migrate-abs-to-spe/FileMigrator.cs
+++ b/Samples/migrate-abs-to-spe/FileMigrator.cs
@@ -1,0 +1,271 @@
+﻿using Azure.Storage.Blobs;
+using Microsoft.Graph.Models;
+
+namespace MigrateABStoSPE
+{
+    public class FileMigrator
+    {
+        private CountdownEvent _countdown;
+        private GraphClientManager _gcm;
+        private AzureBlobManager _abm;
+        private string _containerName;
+        private Dictionary<string, string> directoryListingCache = new Dictionary<string, string>();
+        private const char _separator = '/';
+        private List<string> blobUploadFailed = new List<string>();
+        private List<string> blobUploadSuccessfully = new List<string>();
+        private List<string> blobExist = new List<string>();
+
+        public FileMigrator(
+            int fileCount,
+            GraphClientManager gcm,
+            AzureBlobManager abm)
+        {
+            _countdown = new CountdownEvent(fileCount);
+            _gcm = gcm;
+            _abm = abm;
+            _containerName = _abm.GetContainerName();
+        }
+
+        /// <summary>
+        /// Migrates a list of files to a specified container folder.
+        /// </summary>
+        /// <param name="fileList">The list of files to migrate.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async Task MigrateFiles(IEnumerable<string> fileList)
+        {
+            // Create top level folder
+            DriveItem containerFolder = await _gcm.CheckIfItemExists(_containerName, "root");
+            if (containerFolder == null)
+            {
+                containerFolder = await _gcm.CreateFolder(_containerName, "root");
+            }
+            AddOrUpdateDirectoryListingCache(_containerName, containerFolder.Id);
+
+            foreach (var blobName in fileList)
+            {
+                FileStructure fs = new FileStructure() { blobName = blobName };
+                string parentFolderId = await TraverseFileListing(fs, containerFolder.Id);
+                if (String.IsNullOrEmpty(parentFolderId))
+                {
+                    Utility.ConsoleWriteWithColor($"Failed to create folder/sub folders for this blob {blobName}", ConsoleColor.Red);
+                    _countdown.Signal();
+                    continue;
+                }
+                fs.parentFolderId = parentFolderId;
+
+                Utility.ConsoleWriteWithColor($"Queuing \"{blobName}\" to be migrate", ConsoleColor.Green);
+                ThreadPool.QueueUserWorkItem(MigrateFile, fs);
+            }
+
+            // Wait for all files to be migrated
+            Console.WriteLine("Waiting for all blobs to be migrated - " + DateTime.Now.ToString("HH:mm:ss"));
+            _countdown.Wait();
+            Console.WriteLine("All blobs got processed - " + DateTime.Now.ToString("HH:mm:ss"));
+        }
+
+        /// <summary>
+        /// Migrates a single file to a specified container folder.
+        /// </summary>
+        /// <param name="stateInfo">The state information containing the file structure.</param>
+        internal async void MigrateFile(Object stateInfo)
+        {
+            var fileStructure = (FileStructure)stateInfo;
+
+            // Check if file exists in destination
+            string fileName = Path.GetFileName(fileStructure.blobName);
+            DriveItem fileDI = await _gcm.CheckIfItemExists(fileName, fileStructure.parentFolderId);
+            if (fileDI != null)
+            {
+                Utility.ConsoleWriteWithColor($"{fileName} already exists, will not migrate again.", ConsoleColor.Yellow);
+                blobExist.Add(fileStructure.blobName);
+                _countdown.Signal();
+                return;
+            }
+
+            // Migrate the file
+            bool result = await TransferBlobToSharePointAsync(fileStructure.blobName, fileStructure.parentFolderId);
+            if (result)
+            {
+                Utility.ConsoleWriteWithColor($"Transfer successful: {fileName}!", ConsoleColor.Green);
+                blobUploadSuccessfully.Add(fileStructure.blobName);
+            }
+            else
+            {
+                Utility.ConsoleWriteWithColor($"Transfer failed: {fileName}!", ConsoleColor.Red);
+                blobUploadFailed.Add(fileStructure.blobName);
+            }
+
+            // Signal the countdown event that a file has been migrated
+            _countdown.Signal();
+            return;
+        }
+
+        /// <summary>
+        /// Transfers a blob to SharePoint asynchronously.
+        /// </summary>
+        /// <param name="blobName">The name of the blob to transfer.</param>
+        /// <param name="parentFolderId">The ID of the parent folder in SharePoint.</param>
+        /// <returns>A task representing the asynchronous operation. Returns true if the transfer is successful, false otherwise.</returns>
+        internal async Task<bool> TransferBlobToSharePointAsync(string blobName, string parentFolderId)
+        {
+            try
+            {
+                // Will throw exception if failed to download blob
+                Stream blobStream = await _abm.DownloadBlobStreamAsync(blobName);
+
+                string fileName = Path.GetFileName(blobName);
+                // Will throw exception if failed to upload file
+                await _gcm.UploadStreamToSharePointAsync(blobStream, parentFolderId, fileName);
+
+                return true; // Indicate success
+            }
+            catch (Exception ex)
+            {
+                // Log the exception or handle it as needed
+                Utility.ConsoleWriteWithColor($"An error occurred while migrating failed: {blobName}! Exception: {ex.Message}", ConsoleColor.Red);
+                return false; // Indicate failure
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the list of blob names that failed to upload during the migration process.
+        /// </summary>
+        /// <returns>A list of blob names that failed to upload.</returns>
+        public List<string> GetBlobUploadFailed()
+        {
+            return blobUploadFailed;
+        }
+
+        /// <summary>
+        /// Retrieves the list of blob names that upload successfully during the migration process.
+        /// </summary>
+        /// <returns>A list of blob names that upload successfully.</returns>
+        public List<string> GetBlobUploadSuccessfully()
+        {
+            return blobUploadSuccessfully;
+        }
+
+        /// <summary>
+        /// Retrieves the list of blob names already exist in destination.
+        /// </summary>
+        /// <returns>A list of blob names already exist in destination.</returns>
+        public List<string> GetBlobExist()
+        {
+            return blobExist;
+        }
+
+        /// <summary>
+        /// Retrieves the directory listing from the cache based on the directory name.
+        /// </summary>
+        /// <param name="directoryName">The name of the directory.</param>
+        /// <returns>The directory listing if found in the cache, otherwise null.</returns>
+        private string? GetDirectoryListingCache(string directoryName)
+        {
+            if (directoryListingCache.ContainsKey(directoryName))
+            {
+                return directoryListingCache[directoryName];
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Adds or updates the directory listing cache with the given directory name and ID.
+        /// </summary>
+        /// <param name="directoryName">The name of the directory.</param>
+        /// <param name="id">The ID of the directory.</param>
+        private void AddOrUpdateDirectoryListingCache(string directoryName, string id)
+        {
+            string functionName = "AddOrUpdateDirectoryListingCache";
+            if (directoryListingCache.ContainsKey(directoryName))
+            {
+                Console.WriteLine($"{functionName}: Update cache \"{directoryName}\" with folder information");
+                directoryListingCache[directoryName] = id;
+            }
+            else
+            {
+                Console.WriteLine($"{functionName}: Add to cache \"{directoryName}\" with folder information");
+                directoryListingCache.Add(directoryName, id);
+            }
+        }
+
+        /// <summary>
+        /// Traverses the file listing and creates folders as necessary based on the file path.
+        /// </summary>
+        /// <param name="file">The file structure containing the file name.</param>
+        /// <param name="parentFolderId">The ID of the parent folder.</param>
+        /// <returns>The ID of the last created folder.</returns>
+        private async Task<string> TraverseFileListing(FileStructure file, string parentFolderId)
+        {
+            string functionName = "TraverseFileListing";
+            string filePath = file.blobName;
+            if (filePath.Length == 0)
+            {
+                Utility.ConsoleWriteWithColor($"{functionName}: No folder found", ConsoleColor.Red);
+
+                // Don't throw exception just log and continue
+                return "";
+            }
+
+            // Get directory part of the file path
+            string fullPath = Path.GetDirectoryName(filePath);
+            if (String.IsNullOrEmpty(fullPath))
+            {
+                Console.WriteLine($"{functionName}: File {filePath} is in root");
+
+                return parentFolderId;
+            }
+
+            string newFullPath = _containerName + _separator + fullPath;
+            string folderIdFound = GetDirectoryListingCache(newFullPath);
+            if (!String.IsNullOrEmpty(folderIdFound))
+            {
+                Console.WriteLine($"{functionName}: Full path found in cache: " + newFullPath);
+                return folderIdFound;
+            }
+
+            // Parse for folder path not including the file name and put it in an array
+            var pathSegments = filePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] directoriesParts = pathSegments.Take(pathSegments.Length - 1).ToArray();
+
+            // Traverse the folder listing and create 1 folder at a time
+            string relativePath = _containerName;
+            string newFolderId = parentFolderId;
+            foreach (string folderName in directoriesParts)
+            {
+                string newPath = relativePath + _separator + folderName;
+                string partFolderId = GetDirectoryListingCache(newPath);
+                if (!String.IsNullOrEmpty(partFolderId))
+                {
+                    Console.WriteLine($"{functionName}: New part path found in cache: \"{newPath}\". Part Folder \"{partFolderId}\".");
+                    newFolderId = partFolderId;
+                    relativePath = newPath;
+                    continue;
+                }
+
+                DriveItem subFolder = await _gcm.CheckIfItemExists(folderName, newFolderId);
+                if (subFolder == null)
+                {
+                    subFolder = await _gcm.CreateFolder(folderName, newFolderId);
+                    if (subFolder == null)
+                    {
+                        blobUploadFailed.Add(file.blobName);
+                        Console.WriteLine($"{functionName}: Failed to create folder \"{folderName}\". Parent: {newFolderId}");
+                        return "";
+                    } 
+                }
+                newFolderId = subFolder.Id;
+                AddOrUpdateDirectoryListingCache(newPath, newFolderId);
+
+                relativePath = newPath;
+            }
+
+            return newFolderId;
+        }
+    }
+
+    public class FileStructure
+    {
+        public string blobName { get; set; }
+        public string parentFolderId { get; set; }
+    }
+}

--- a/Samples/migrate-abs-to-spe/GraphClientManager.cs
+++ b/Samples/migrate-abs-to-spe/GraphClientManager.cs
@@ -1,0 +1,210 @@
+﻿using Azure.Identity;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Graph.Drives.Item.Items.Item.CreateUploadSession;
+using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
+using System.Net;
+
+namespace MigrateABStoSPE
+{
+    public class GraphClientManager: IGraphClientManager
+    {
+        private GraphServiceClient _graphClient;
+        private string _clientId;
+        private string _containerId;
+        string[] _scopes = { "User.Read", "FileStorageContainer.Selected" };
+        // This is a recommended size as a starting point. You can experiment with different chunk sizes.
+        // For example, increasing the chunk size might reduce the number of requests but could lead to
+        // larger data transfers that might be more susceptible to network issues.
+        private const int _maxChunkSize = 320 * 1024; // 320 KB - Upload the file in chunks
+
+        public GraphClientManager(GraphServiceClient graphClient, string tenantId, string clientId, string containerId, string?[] scopes)
+        {
+            if (graphClient == null)
+            {
+                if (scopes != null)
+                {
+                    _scopes = scopes;
+                }
+
+                InteractiveBrowserCredentialOptions interactiveBrowserCredentialOptions = new InteractiveBrowserCredentialOptions()
+                {
+                    TenantId = tenantId,
+                    ClientId = clientId,
+                    RedirectUri = new Uri("http://localhost"),
+                };
+                InteractiveBrowserCredential interactiveBrowserCredential = new InteractiveBrowserCredential(interactiveBrowserCredentialOptions);
+
+                graphClient = new GraphServiceClient(interactiveBrowserCredential, scopes, null);
+            }
+
+            _graphClient = graphClient;
+            _clientId = clientId;
+            _containerId = containerId;
+        }
+
+        public async Task<bool> Authenticate()
+        {
+            try
+            {
+                var user = await _graphClient.Me.GetAsync();
+                if (user != null)
+                {
+                    Utility.ConsoleWriteWithColor($"Graph Authenticated Successfully", ConsoleColor.Magenta);
+                    return true;
+                }
+                Utility.ConsoleWriteWithColor($"Graph failed To Authenticate.", ConsoleColor.Red);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Utility.ConsoleWriteWithColor($"Graph failed To Authenticate. Exception: {ex.Message}.", ConsoleColor.Red);
+                return false;
+            }
+        }
+
+        public async Task<DriveItem?> CreateFolder(string folderName, string parentFolderId)
+        {
+            string functionName = "CreateFolder";
+
+            var folder = new DriveItem
+            {
+                Name = folderName,
+                Folder = new Folder(),
+                AdditionalData = new Dictionary<string, object>()
+                {
+                    { "@microsoft.graph.conflictBehavior", "fail" }
+                }
+            };
+            try
+            {
+                // Retry has already been implemented in the Graph SDK
+                var createdFolder = await _graphClient.Drives[_containerId].Items[parentFolderId].Children.PostAsync(folder);
+                if (createdFolder != null)
+                {
+                    Utility.ConsoleWriteWithColor($"{functionName}: Folder Created \"{folderName}\". Parent: {parentFolderId}", ConsoleColor.Cyan);
+                    return createdFolder;
+                }
+                Utility.ConsoleWriteWithColor($"{functionName}: Failed to create folder \"{folderName}\". Parent: {parentFolderId}", ConsoleColor.Red);
+                return null;
+            }
+            catch (ODataError odataError)
+            {
+                HandleUnsuccessfulResponse(odataError, "Create folder request failed", parentFolderId, folderName);
+
+                return null;
+            }
+            catch (Exception ex)
+            {
+                HandleUnsuccessfulResponse(ex, "Failed to create folder", parentFolderId, folderName);
+
+                return null;
+            }
+        }
+
+        public async Task<DriveItem?> CheckIfItemExists(string itemPath, string parentFolderId)
+        {
+            string functionName = "CheckIfItemExists";
+            try
+            {
+                var item = await _graphClient.Drives[_containerId].Items[parentFolderId].ItemWithPath(itemPath).GetAsync();
+
+                if (item != null)
+                {
+                    Utility.ConsoleWriteWithColor($"{functionName} - Item name: \"{itemPath}\" exist. Parent: \"{parentFolderId}\"", ConsoleColor.Yellow);
+                    return item;
+                }
+            }
+            catch (ODataError odataError)
+            {
+                HandleUnsuccessfulResponse(odataError, "Check item exists request failed", parentFolderId, itemPath);
+            }
+            catch (Exception e)
+            {
+                HandleUnsuccessfulResponse(e, "Failed to check item exists", parentFolderId, itemPath);
+
+                Console.WriteLine($"An exception occurred while checking to see if item exists: {itemPath}: {e.Message}");
+            }
+
+            return null;
+        }
+
+        public async Task<bool> UploadStreamToSharePointAsync(Stream stream, string parentFolderId, string fileName)
+        {
+            var uploadSessionRequestBody = new CreateUploadSessionPostRequestBody()
+            {
+                AdditionalData = new Dictionary<string, object>
+                {
+                    { "@microsoft.graph.conflictBehavior", "fail" }
+                }
+            };
+
+            try
+            {
+                var uploadSession = await _graphClient.Drives[_containerId]
+                    .Items[parentFolderId]
+                    .ItemWithPath(fileName)
+                    .CreateUploadSession
+                    .PostAsync(uploadSessionRequestBody);
+
+                var fileUploadTask = new LargeFileUploadTask<DriveItem>(uploadSession, stream, _maxChunkSize, _graphClient.RequestAdapter);
+
+                IProgress<long> progress = new Progress<long>(prog => Console.WriteLine($"Uploaded {fileName} {prog} bytes"));
+
+                var uploadResult = await fileUploadTask.UploadAsync(progress);
+                if (uploadResult.UploadSucceeded)
+                {
+                    Console.WriteLine($"Upload succeeded: {fileName}!");
+                    return true;
+                }
+                else
+                {
+                    Console.WriteLine($"Upload failed: {fileName}.");
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Utility.ConsoleWriteWithColor($"An error occurred while uploading: {fileName}! Exception: {ex.Message}", ConsoleColor.Red);
+                throw ex;
+            }
+        }
+
+        /// <summary>
+        /// Handles an unsuccessful response from the Graph API.
+        /// </summary>
+        /// <param name="error">The ODataError or Exception object representing the error response.</param>
+        /// <param name="errorString">The error string to display.</param>
+        /// <param name="parentFolderId">The ID of the parent folder.</param>
+        /// <param name="item">The name of the item.</param>
+        private void HandleUnsuccessfulResponse(Object error, string errorString, string parentFolderId, string item)
+        {
+            Utility.ConsoleWriteWithColor($"{errorString} - Item name: \"{item}\". Parent: \"{parentFolderId}\"", ConsoleColor.Red);
+
+            if (error is ODataError oDataError)
+            {
+                switch (oDataError.ResponseStatusCode)
+                {
+                    case (int)HttpStatusCode.BadRequest:
+                        Utility.ConsoleWriteWithColor($"Error: {oDataError.Error.Message}. Status code: {oDataError.ResponseStatusCode}.", ConsoleColor.Red);
+                        break;
+                    case (int)HttpStatusCode.Conflict:
+                        Utility.ConsoleWriteWithColor($"Warning: {oDataError.Error.Message}. Status code: {oDataError.ResponseStatusCode}.", ConsoleColor.Yellow);
+                        break;
+                    case (int)HttpStatusCode.NotFound:
+                        Utility.ConsoleWriteWithColor($"Warning: Item not found {item}", ConsoleColor.Yellow);
+                        break;
+                    default:
+                        Utility.ConsoleWriteWithColor($"An error occurred. Please try again later. Status code: {oDataError.ResponseStatusCode}. Error message: {oDataError.Error.Message}", ConsoleColor.Red);
+                        break;
+                }
+                return;
+            }
+            if (error is Exception e)
+            {
+                Utility.ConsoleWriteWithColor($"Unexpected exception occurred. Error message: {e.Message}", ConsoleColor.Red);
+            }
+        }
+    }
+}

--- a/Samples/migrate-abs-to-spe/IGraphClientManager.cs
+++ b/Samples/migrate-abs-to-spe/IGraphClientManager.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Graph.Models;
+
+namespace MigrateABStoSPE
+{
+    public interface IGraphClientManager
+    {
+        /// <summary>
+        /// Authenticates the Graph client.
+        /// </summary>
+        /// <returns>A boolean indicating whether the authentication was successful or not.</returns>
+        Task<bool> Authenticate();
+
+        /// <summary>
+        /// Creates a folder with the specified name under the given parent folder ID.
+        /// </summary>
+        /// <param name="folderName">The name of the folder to create.</param>
+        /// <param name="parentFolderId">The ID of the parent folder.</param>
+        /// <returns>The created DriveItem representing the folder.</returns>
+        Task<DriveItem?> CreateFolder(string folderName, string parentFolderId);
+
+        /// <summary>
+        /// Checks if an item with the specified path exists under the given parent folder ID.
+        /// </summary>
+        /// <param name="itemPath">The path of the item to check.</param>
+        /// <param name="parentFolderId">The ID of the parent folder.</param>
+        /// <returns>The DriveItem representing the item if it exists, otherwise null.</returns>
+        Task<DriveItem?> CheckIfItemExists(string itemPath, string parentFolderId);
+
+        /// <summary>
+        /// Uploads a stream to SharePoint asynchronously. This stream is from ABS.
+        /// </summary>
+        /// <param name="stream">The stream to upload.</param>
+        /// <param name="parentFolderId">The ID of the parent folder.</param>
+        /// <param name="fileName">The name of the file.</param>
+        Task<bool> UploadStreamToSharePointAsync(Stream stream, string parentFolderId, string fileName);
+    }
+}

--- a/Samples/migrate-abs-to-spe/MigrateABStoSPE.csproj
+++ b/Samples/migrate-abs-to-spe/MigrateABStoSPE.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/migrate-abs-to-spe/MigrateABStoSPE.sln
+++ b/Samples/migrate-abs-to-spe/MigrateABStoSPE.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35027.167
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MigrateABStoSPE", "MigrateABStoSPE.csproj", "{2633350D-0451-49A2-BDFA-00445ADD6970}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MigrateABStoSPETests", "..\MigrateABStoSPETests\MigrateABStoSPETests.csproj", "{6F944610-B4CB-428C-86FB-D399B9009B5C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2633350D-0451-49A2-BDFA-00445ADD6970}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2633350D-0451-49A2-BDFA-00445ADD6970}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2633350D-0451-49A2-BDFA-00445ADD6970}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2633350D-0451-49A2-BDFA-00445ADD6970}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F944610-B4CB-428C-86FB-D399B9009B5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F944610-B4CB-428C-86FB-D399B9009B5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F944610-B4CB-428C-86FB-D399B9009B5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F944610-B4CB-428C-86FB-D399B9009B5C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C0F34EE9-B986-4835-888B-BEBBF3598B5C}
+	EndGlobalSection
+EndGlobal

--- a/Samples/migrate-abs-to-spe/Program.cs
+++ b/Samples/migrate-abs-to-spe/Program.cs
@@ -1,0 +1,186 @@
+﻿using CommandLine;
+
+namespace MigrateABStoSPE
+{
+    internal class Program
+    {
+        class Options
+        {
+            [Option('s', "sasurl", Required = true, HelpText = "container-level SAS URL - a azure blob container level SAS url.")]
+            public string ContainerLevelSASUrl { get; set; }
+            [Option('t', "tenantid", Required = true, HelpText = "SPE tenant id - the tenant id that we are authenticating against.")]
+            public string TenantId { get; set; }
+            [Option('c', "clientid", Required = true, HelpText = "SPE client id - the client id that we are authenticating against.")]
+            public string ClientId { get; set; }
+            [Option('o', "containerid", Required = true, HelpText = "SPE container id - the container id that we are migrating content to.")]
+            public string ContainerId { get; set; }
+            [Option('b', "blobfile", Required = false, HelpText = "(optional) File name with full path that contains the blob list.")]
+            public string? BlobFiles { get; set; }
+            [Option('f', "outputfile", Required = false, HelpText = "(optional) File name with full path where to output failed blobs.")]
+            public string? OutputFile { get; set; }
+        }
+
+        public static async Task Main(string[] args)
+        {
+            string containerLevelSASUrl = String.Empty;
+            string tenantId = String.Empty;
+            string clientId = String.Empty;
+            string containerId = String.Empty;
+            string blobList = String.Empty;
+            string outputFile = String.Empty;
+            IEnumerable<string> blobListInJson = null;
+
+            Parser.Default.ParseArguments<Options>(args)
+            .WithParsed<Options>(opts => HandleOptions(opts, out containerLevelSASUrl, out tenantId, out clientId, out containerId, out blobList, out outputFile))
+            .WithNotParsed<Options>((errs) => {
+                ShowUsage();
+                Environment.Exit(1);
+            });
+
+            try
+            {
+                ValidateArguments(containerLevelSASUrl, clientId, blobList, out blobListInJson);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                ShowUsage();
+                return;
+            }
+
+            // Authenticate with SPE
+            GraphClientManager graphClientManager = new GraphClientManager(null, tenantId, clientId, containerId, null);
+            bool graphAuthenticated = await graphClientManager.Authenticate();
+            if (!graphAuthenticated)
+            {
+                return;
+            }
+
+            // Instantiates an ABS, authenticate happens when accessing the blob
+            AzureBlobManager azureBlobManager = new AzureBlobManager(containerLevelSASUrl);
+            if (blobListInJson == null)
+            {
+                // No blob list provided, get all blobs in the container to migrate
+                blobListInJson = await azureBlobManager.ListBlobsAsync();
+                if (blobListInJson == null)
+                {
+                    Utility.ConsoleWriteWithColor("No blobs found in the container.", ConsoleColor.Red);
+                    return;
+                }
+            }
+
+            FileMigrator migrator = new FileMigrator(
+                blobListInJson.Count(),
+                graphClientManager,
+                azureBlobManager);
+            try
+            {
+                await migrator.MigrateFiles(blobListInJson);
+            }
+            catch (Exception ex)
+            {
+                Utility.ConsoleWriteWithColor($"This exception should not occur because most exceptions should of already been handled. Exception {ex.Message}", ConsoleColor.Red);
+            }
+
+            List<string> blobUploadFailed = migrator.GetBlobUploadFailed();
+            List<string> blobUploadSucceeded = migrator.GetBlobUploadSuccessfully();
+            List<string> blobExist = migrator.GetBlobExist();
+            if (blobUploadFailed.Count > 0)
+            {
+                HandleFailedBlobs(blobUploadFailed, blobList, outputFile, containerLevelSASUrl, clientId, containerId);
+            }
+            Utility.ConsoleWriteWithColor($"Stats out of {blobListInJson.Count()} blobs", ConsoleColor.Green);
+            Utility.ConsoleWriteWithColor($"Failed: {blobUploadFailed.Count()} out of {blobListInJson.Count()} blob(s)", ConsoleColor.Green);
+            Utility.ConsoleWriteWithColor($"Migrated: {blobUploadSucceeded.Count()} out of {blobListInJson.Count()} blob(s)", ConsoleColor.Green);
+            Utility.ConsoleWriteWithColor($"Already exists: {blobExist.Count()} out of {blobListInJson.Count()} blob(s)", ConsoleColor.Green);
+        }
+
+        static void HandleFailedBlobs(IEnumerable<string> blobUploadFailed, string blobFile, string outputFile, string containerLevelSASUrl, string clientId, string containerId)
+        {
+            string useFileName = !string.IsNullOrEmpty(outputFile) ? outputFile : blobFile;
+            string fullPath = Path.GetFullPath(useFileName);
+
+            // Get the filename without the extension
+            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fullPath);
+
+            string fileExtension = Path.GetExtension(fullPath);
+
+            // Combine the directory path with the filename without extension
+            string directoryPath = Path.GetDirectoryName(fullPath);
+            string fullPathWithoutExtension = Path.Combine(directoryPath, fileNameWithoutExtension);
+
+            string newOutputFile = fullPathWithoutExtension + "1" + fileExtension;
+            if (String.IsNullOrEmpty(outputFile))
+            {
+                outputFile = fullPathWithoutExtension + "1" + fileExtension;
+                newOutputFile = fullPathWithoutExtension + "11" + fileExtension;
+            }
+
+            Utility.ConsoleWriteWithColor($"There are the blobs that failed to upload. The failed blobs are saved in {outputFile}.", ConsoleColor.Red);
+            Utility.ConsoleWriteWithColor($"To re-run, copy the command as below", ConsoleColor.Red);
+            Utility.ConsoleWriteWithColor($"dotnet run Program.cs -- --sasurl \"{containerLevelSASUrl}\" --clientid \"{clientId}\" --containerid \"{containerId}\" --blobfile \"{outputFile}\" --outputfile \"{newOutputFile}\"", ConsoleColor.Red);
+
+            using (StreamWriter writer = new StreamWriter(outputFile))
+            {
+                foreach (string item in blobUploadFailed)
+                {
+                    writer.WriteLine(item);
+                }
+            }
+        }
+
+        static void HandleOptions(Options opts, out string sasUrl, out string tenantId, out string clientId, out string containerId, out string blobList, out string outputFile)
+        {
+            sasUrl = opts.ContainerLevelSASUrl;
+            tenantId = opts.TenantId;
+            clientId = opts.ClientId;
+            containerId = opts.ContainerId;
+            blobList = opts.BlobFiles ?? String.Empty;
+            outputFile = opts.OutputFile ?? String.Empty;
+        }
+
+        static void ShowUsage()
+        {
+            Console.WriteLine("Usage: dotnet run Program.cs -- --sasurl \"<sas url>\" --tenantid \"<owning tenant id>\" --clientid \"<client id>\" --containerid \"<container id>\" [--blobfile \"<file name>\" --outputfile \"<file name>\"]");
+        }
+
+        /// <summary>
+        /// Validates the arguments passed to the program.
+        /// </summary>
+        /// <param name="containerLevelSASUrl">The container-level SAS URL.</param>
+        /// <param name="clientId">The Graph client ID.</param>
+        /// <param name="blobFiles">The list of blobs to copy.</param>
+        /// <param name="blobListJson">The list of blobs to copy in JSON format.</param>
+        /// <exception cref="ArgumentException">Thrown when the container level SAS URL is invalid, the Graph client ID is not a valid GUID, or the blob list format is invalid.</exception>
+        private static void ValidateArguments(string containerLevelSASUrl, string clientId, string blobFiles, out IEnumerable<string> blobListJson)
+        {
+            blobListJson = null;
+
+            Uri uriResult;
+            bool isValidUri = Uri.TryCreate(containerLevelSASUrl, UriKind.Absolute, out uriResult) &&
+                (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+            if (!isValidUri)
+            {
+                throw new ArgumentException("Invalid container level SAS URL format.");
+            }
+
+            bool isValid = Guid.TryParse(clientId, out Guid guid);
+            if (!isValid)
+            {
+                throw new ArgumentException("The SPE clientId is not a valid GUID.");
+            }
+
+            if (!String.IsNullOrEmpty(blobFiles))
+            {
+                try
+                {
+                    blobListJson = File.ReadAllLines(blobFiles);
+                }
+                catch (Exception ex)
+                {
+                    throw new ArgumentException($"Cannot read file. Exception: {ex.Message}.");
+                }
+            }            
+        }
+    }
+}

--- a/Samples/migrate-abs-to-spe/README.md
+++ b/Samples/migrate-abs-to-spe/README.md
@@ -1,0 +1,50 @@
+# Migrate Azure Blob Storage Container To SharePoint Embedded Container Tutorial
+
+The application is a console application that migrates content from Azure Blob Storage to SharePoint Embedded. It uses the ABS SDK download the blob and uses Graph SDK and and upload to the SPE container.
+
+# Table of Contents
+1. [Requirements](#requirements)
+1. [Quick setup](#quick-setup)
+
+# Requirements
+* An Azure Blob Storage account with a container and its container level SAS URL
+* An [Azure account](https://portal.azure.com)
+* A SharePoint Tenant where you will create your containers and its Tenant Id
+* An onboarded application id (sometimes called client id) and its corresponding ContainerTypeId
+* Create new App Registration in [Azure's App Registration portal](https://portal.azure.com).
+* In the App Registration, add a new Mobile & Console application platform in [Azure's App Registration Authenticate portal](https://portal.azure.com)
+* A ContainerType
+* A Container
+* Having the application registered in the consuming tenant (even if the owner of the application is the same as the consuming)
+* Having the containerType registered in the consuming tenant (even if the owner of the CT is the same as the consuming)
+
+# Quick setup
+
+## 1. Clone the repository
+Clone the repository if you haven't done so and navigate to this application.
+```
+git clone https://github.com/microsoft/SharePoint-Embedded-Samples.git
+cd SharePoint-Embedded-Samples\samples\migrate-abs-to-spe
+```
+
+## 2. Build and run
+### From Visual Studio
+Build and start debugging your application.
+
+This will automatically build the project
+
+### From a terminal
+If you use [dotnet command](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet), from the project's directory, type
+```
+# from samples\migrate-abs-to-spe
+dotnet build
+
+# Parameters
+# --sasurl : container-level SAS URL - a azure blob container level SAS url.
+# --tenantid : SPE tenant id - the tenant id that we are authenticating against.
+# --clientid : SPE client id - the client id that we are authenticating against.
+# --containerid : SPE container id - the container id that we are migrating content to
+# --blobfile : (optional) File name with full path that contains the blob list. If it is not provided, the application will download all blobs in the container.
+# --outputfile : (optional) File name with full path where to output failed blobs.
+dotnet run Program.cs -- --sasurl "{containerLevelSASUrl}" --clientid "{clientId}" --containerid "{containerId}" [--blobfile "{outputFile}" --outputfile "{newOutputFile}"]"
+```

--- a/Samples/migrate-abs-to-spe/Utility.cs
+++ b/Samples/migrate-abs-to-spe/Utility.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MigrateABStoSPE
+{
+    internal class Utility
+    {
+        public static void ConsoleWriteWithColor(string message, ConsoleColor color)
+        {
+            Console.ForegroundColor = color;
+            Console.WriteLine(message);
+            Console.ResetColor();
+        }
+    }
+}


### PR DESCRIPTION
A sample app to help customers if they want to migrate the content from ABS to SPE.

It is not meant to replace the Migration Manager Platform or Graph. It is a starting place so customer can either create their own app or use to sample app to migrate their content.