### PR TITLE
Adds "Open as PDF" option to ContainerActionBar

### DIFF
--- a/Samples/spe-typescript-react-azurefunction/react-client/src/common/FileSchemas.ts
+++ b/Samples/spe-typescript-react-azurefunction/react-client/src/common/FileSchemas.ts
@@ -45,13 +45,17 @@ export class IDriveItem implements DriveItem {
     public get isWordDocument(): boolean {
         return this.isFolder ? false : IDriveItem._wordExtensions.includes(this.extension || '');
     }
-
+    
     public get isExcelDocument(): boolean {
         return this.isFolder ? false : IDriveItem._excelExtensions.includes(this.extension || '');
     }
-
+    
     public get isPowerPointDocument(): boolean {
         return this.isFolder ? false : IDriveItem._powerPointExtensions.includes(this.extension || '');
+    }
+
+    public get isPdfConvertibleDocument(): boolean {
+        return this.isFolder ? false : IDriveItem._pdfConvertibleExtensions.includes(this.extension || '');
     }
 
     public get desktopUrl(): string | undefined {
@@ -77,6 +81,7 @@ export class IDriveItem implements DriveItem {
     private static readonly _wordExtensions: string[] = ['doc', 'docx', 'docm', 'dot', 'dotx', 'dotm'];
     private static readonly _excelExtensions: string[] = ['xls', 'xlsx', 'xlsm', 'xlt', 'xltx', 'xltm'];
     private static readonly _powerPointExtensions: string[] = ['ppt', 'pptx', 'pptm', 'pot', 'potx', 'potm', 'pps', 'ppsx', 'ppsm'];
+    private static readonly _pdfConvertibleExtensions: string[] = ['csv', 'doc', 'docx', 'odp', 'ods', 'odt', 'pot', 'potm', 'potx', 'pps', 'ppsx', 'ppsm', 'ppt', 'pptm', 'pptx', 'rtf', 'xls', 'xlsx'];
     private static readonly _allExtensions: string[] = [...IDriveItem._wordExtensions, ...IDriveItem._excelExtensions, ...IDriveItem._powerPointExtensions];
 
     public static isOfficeExtension(extension: string | undefined): boolean {

--- a/Samples/spe-typescript-react-azurefunction/react-client/src/components/ContainerActionBar.tsx
+++ b/Samples/spe-typescript-react-azurefunction/react-client/src/components/ContainerActionBar.tsx
@@ -29,6 +29,7 @@ import {
     PreviewLink20Filled,
     Add20Filled,
     Folder24Filled,
+    DocumentPdf20Regular
 } from '@fluentui/react-icons';
 import { IDriveItem } from '../common/FileSchemas';
 import { GraphProvider } from '../providers/GraphProvider';
@@ -244,6 +245,22 @@ export const ContainerActionBar: React.FunctionComponent<IContainerActionBarProp
                                     </MenuItem>
                                 )}
                             </>)}
+
+                            {props.selectedItem.isPdfConvertibleDocument && (
+                                <MenuItem
+                                    icon={<DocumentPdf20Regular />}
+                                    onClick={async () => {
+                                        const pdfUrl = await filesApi.getPdfUrl(
+                                            props.selectedItem?.parentReference?.driveId ?? "",
+                                            props.selectedItem?.id ?? ""
+                                          );                
+                                          window.open(pdfUrl, "_blank");                                        
+                                    }}
+                                >
+                                    Open as PDF
+                                </MenuItem>    
+                            )} 
+
                             <MenuItem
                                 icon={<PreviewLink20Filled />}
                                 onClick={() => props.onFilePreviewSelected?.(props.selectedItem!)}

--- a/Samples/spe-typescript-react-azurefunction/react-client/src/providers/GraphProvider.ts
+++ b/Samples/spe-typescript-react-azurefunction/react-client/src/providers/GraphProvider.ts
@@ -100,4 +100,16 @@ export class GraphProvider {
         const response = await this._providerClient?.api(endpoint).get();
         return response.webUrl;
     }
+
+    public async getPdfUrl(
+        driveId: string,
+        itemId: string
+      ): Promise<URL> {
+        const endpoint = `/drives/${driveId}/items/${itemId}/content?format=pdf`;
+        // NB: We use the `raw` response type so that we can capture the redirected URL of the PDF file.
+        // See: https://learn.microsoft.com/en-us/graph/api/driveitem-get-content-format?view=graph-rest-1.0&tabs=http#response
+        const response = await this._providerClient?.api(endpoint).responseType(Graph.ResponseType.RAW).get();    
+        const url = new URL(response.url);
+        return url;
+    }        
 }


### PR DESCRIPTION
Hi @marcwindle! As discussed yesterday at the SharePoint Embedded London workshop, here's the PR for adding an "Open as PDF" option to the Container Action Bar:

![image](https://github.com/user-attachments/assets/6b7bcd9a-7950-4924-be25-aa78b024df47)

It uses the format options file extension list from: https://learn.microsoft.com/en-us/graph/api/driveitem-get-content-format?view=graph-rest-1.0&tabs=http#format-options to determine if the drive item is PDF convertible or not.

Hope it helps!