### PR TITLE
Passing a fluentui@8.x ITheme object to the ChatODSP application.

### DIFF
--- a/sharepointembedded-chatembedded-react/package.json
+++ b/sharepointembedded-chatembedded-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/sharepointembedded-copilotchat-react",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A sharepoint embedded copilot chat react componenet that can be integrated into your sharepoint embedded custom react+typescript applications.",
   "repository": {
     "type": "git",
@@ -31,12 +31,13 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@fluentui/react": "^8.122.0",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.0",
     "@types/node": "^22.7.2",
-    "@types/react": "^17.0.2",
+    "@types/react": "^18.3.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^6.0.1",
@@ -48,6 +49,7 @@
   },
   "peerDependencies": {
     "react": ">=17.0.2",
-    "react-dom": ">=17.0.2"
+    "react-dom": ">=17.0.2",
+    "@fluentui/react": ">=8.1.0" 
   }
 }

--- a/sharepointembedded-chatembedded-react/src/ChatEmbedded.tsx
+++ b/sharepointembedded-chatembedded-react/src/ChatEmbedded.tsx
@@ -22,7 +22,8 @@
  * SOFTWARE
  */
 import React from 'react';
-import ChatEmbeddedAPI, {IChatEmbeddedApiAuthProvider, ChatLaunchConfig} from './ChatEmbeddedAPI';
+import ChatEmbeddedAPI, {IChatEmbeddedApiAuthProvider, ChatLaunchConfig, getSafeTheme} from './ChatEmbeddedAPI';
+import { ITheme } from '@fluentui/react';
 
 interface ChatEmbeddedProps {
     authProvider: IChatEmbeddedApiAuthProvider,
@@ -30,6 +31,7 @@ interface ChatEmbeddedProps {
     onNotification?: (data: any) => void;
     onChatClose?: (data: any) => void;
     style?: React.CSSProperties;
+    themeV8?: ITheme;
 }
 
 export type { IChatEmbeddedApiAuthProvider, ChatLaunchConfig};
@@ -38,8 +40,9 @@ export { ChatEmbeddedAPI };
 export default function ChatEmbedded(props: ChatEmbeddedProps) {
     const [chatApi, setChatApi] = React.useState<ChatEmbeddedAPI | undefined>();
 
-    const {authProvider, onApiReady, onNotification, style} = props;
+    const {authProvider, onApiReady, onNotification, style, themeV8} = props;
 
+    const safeThemeV8 = getSafeTheme(themeV8);
     const onIFrameRef = React.useCallback((iframeElement: any) => {
         if (iframeElement && iframeElement.contentWindow) {
             if (!chatApi) {
@@ -47,6 +50,7 @@ export default function ChatEmbedded(props: ChatEmbeddedProps) {
                     contentWindow: iframeElement.contentWindow,
                     onNotification,
                     authProvider,
+                    themeV8: safeThemeV8
                 });
                 setChatApi(newApi);
                 onApiReady(newApi);

--- a/sharepointembedded-chatembedded-react/src/ChatEmbeddedAPI.ts
+++ b/sharepointembedded-chatembedded-react/src/ChatEmbeddedAPI.ts
@@ -22,6 +22,7 @@
  * SOFTWARE
  */
 import { ICustomPrompts, ICustomTheme, IHeader, IThemeOptions, IDataSourcesProps, IZeroQueryPrompts } from "./types";
+import { ITheme, useTheme } from '@fluentui/react';
 
 export interface IChatEmbeddedConfig {
     contentWindow: Window;
@@ -29,6 +30,7 @@ export interface IChatEmbeddedConfig {
     onChatReady?: () => void;
     onChatClose?: (data: object) => void;
     onNotification?: (data: object) => void;
+    themeV8: ITheme;
 }
 
 export interface IChatEmbeddedApiAuthProvider {
@@ -50,6 +52,7 @@ class ChatEmbeddedAPI {
 
     private _customPrompts: ICustomPrompts = {};
     private _theme: ICustomTheme = {};
+    private _themeV8: ITheme;
 
     private _header: IHeader;
     private _contentWindow: Window;
@@ -73,6 +76,7 @@ class ChatEmbeddedAPI {
 
         this._messageListener = this._onWindowMessage.bind(this);
         this._header = this._defaultHeader;
+        this._themeV8 = config.themeV8;
     }
 
     public get channelId() {
@@ -224,6 +228,7 @@ class ChatEmbeddedAPI {
                         dataSources: this._dataSources,
                     },
                     theme: this._theme,
+                    themeV8: this._themeV8
                 },
             }
         });
@@ -375,6 +380,21 @@ class ChatEmbeddedAPI {
             ...themeOptions.customTheme,
         };
     }
+
+}
+
+export function getSafeTheme(themeOptions?: ITheme): ITheme {
+    // The spread operator is used to merge the default theme and the partial theme options,
+    // with properties in themeV8Options overriding those in the default themeV8
+
+    const themeV8: ITheme = {
+        ...useTheme(),
+        ...(themeOptions ?? {}),
+      };
+    // Remove components from theme to avoid serializing errors
+    const {components, ...safeTheme} = themeV8;
+    void components;
+    return safeTheme;
 }
 
 export default ChatEmbeddedAPI;


### PR DESCRIPTION
This pull request enables the send feedback modal popup within the iFrame to work when clicking the thumbs up/down button on copilot responses.
 
For compatibliity reasons the theme object ought to be constructed using the 8.x version of fluentui.

For safe serialization a utility function to remove components from the theme has been included.