### PR TITLE
Require the Copilot chat to be loaded under inside a container site

### DIFF
--- a/sharepointembedded-chatembedded-react/package.json
+++ b/sharepointembedded-chatembedded-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/sharepointembedded-copilotchat-react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A sharepoint embedded copilot chat react componenet that can be integrated into your sharepoint embedded custom react+typescript applications.",
   "repository": {
     "type": "git",

--- a/sharepointembedded-chatembedded-react/src/ChatEmbedded.tsx
+++ b/sharepointembedded-chatembedded-react/src/ChatEmbedded.tsx
@@ -32,6 +32,7 @@ interface ChatEmbeddedProps {
     onChatClose?: (data: any) => void;
     style?: React.CSSProperties;
     themeV8?: ITheme;
+    containerId: string;
 }
 
 export type { IChatEmbeddedApiAuthProvider, ChatLaunchConfig};
@@ -40,7 +41,7 @@ export { ChatEmbeddedAPI };
 export default function ChatEmbedded(props: ChatEmbeddedProps) {
     const [chatApi, setChatApi] = React.useState<ChatEmbeddedAPI | undefined>();
 
-    const {authProvider, onApiReady, onNotification, style, themeV8} = props;
+    const {authProvider, onApiReady, onNotification, style, themeV8, containerId} = props;
 
     const safeThemeV8 = getSafeTheme(themeV8);
     const onIFrameRef = React.useCallback((iframeElement: any) => {
@@ -50,7 +51,9 @@ export default function ChatEmbedded(props: ChatEmbeddedProps) {
                     contentWindow: iframeElement.contentWindow,
                     onNotification,
                     authProvider,
-                    themeV8: safeThemeV8
+                    themeV8: safeThemeV8,
+                    containerId
+
                 });
                 setChatApi(newApi);
                 onApiReady(newApi);

--- a/sharepointembedded-chatembedded-react/src/ChatEmbeddedAPI.ts
+++ b/sharepointembedded-chatembedded-react/src/ChatEmbeddedAPI.ts
@@ -88,6 +88,11 @@ class ChatEmbeddedAPI {
         this._messageListener = this._onWindowMessage.bind(this);
         this._header = this._defaultHeader;
         this._themeV8 = config.themeV8;
+        // Validate the containerId to match the specific format
+        const containerIdPattern = /^b![a-zA-Z0-9-_]+$/;
+        if (!config.containerId || !containerIdPattern.test(config.containerId)) {
+            throw new Error('Invalid containerId format');
+        }
         this._containerId = config.containerId;
     }
 
@@ -117,7 +122,6 @@ class ChatEmbeddedAPI {
         };
     }
 
-    private readonly _path: string = "/_layouts/15/chatembedded.aspx";
     private readonly _defaultHeader: IHeader = {
         title: "SharePoint Embedded Chat",
         hideIcon: true,
@@ -151,12 +155,6 @@ class ChatEmbeddedAPI {
         interface IApiResponse {
             sharepointIds: ISharepointIds;
         }
-        // Validate the containerId to match the specific format
-        const containerIdPattern = /^b![a-zA-Z0-9-_]+$/;
-        if (!this._containerId || !containerIdPattern.test(this._containerId)) {
-            throw new Error('Invalid containerId format');
-        }
-        
         const registerApi = `${this.authProvider.hostname}/_api/v2.1/drives/${this._containerId}?$select=sharePointIds`;
         const response = await fetch(registerApi, {
             method: 'GET',
@@ -448,7 +446,6 @@ class ChatEmbeddedAPI {
             ...themeOptions.customTheme,
         };
     }
-
 }
 
 export function getSafeTheme(themeOptions?: ITheme): ITheme {

--- a/sharepointembedded-chatembedded-react/src/ChatEmbeddedAPI.ts
+++ b/sharepointembedded-chatembedded-react/src/ChatEmbeddedAPI.ts
@@ -151,6 +151,12 @@ class ChatEmbeddedAPI {
         interface IApiResponse {
             sharepointIds: ISharepointIds;
         }
+        // Validate the containerId to match the specific format
+        const containerIdPattern = /^b![a-zA-Z0-9-_]+$/;
+        if (!this._containerId || !containerIdPattern.test(this._containerId)) {
+            throw new Error('Invalid containerId format');
+        }
+        
         const registerApi = `${this.authProvider.hostname}/_api/v2.1/drives/${this._containerId}?$select=sharePointIds`;
         const response = await fetch(registerApi, {
             method: 'GET',


### PR DESCRIPTION
This PR requires a containerid be passed into the constructor of the ChatEmbedded react component. During load it acquires the siteUrl for the containerid using the provided 3P Sharepoint Access token and builds the correct URL to load the copilot chat iFrame.

![image](https://github.com/user-attachments/assets/cdb0aa69-7eee-4beb-a54e-9208b29a591a)
