### PR TITLE
Updates ASP.NET webservice sample to .Net 8. Closes #77

### DIFF
--- a/Samples/asp.net-webservice/Demo.csproj
+++ b/Samples/asp.net-webservice/Demo.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>Demo-99C23405-82C0-4B27-8A15-F3B0744E06BE</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
     <RootNamespace>Demo</RootNamespace>
@@ -14,24 +14,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="6.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.16">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.16" />
     <PackageReference Include="Microsoft.Graph" Version="4.31.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.1" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.24.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.9" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.9.1" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="3.9.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/asp.net-webservice/README.md
+++ b/Samples/asp.net-webservice/README.md
@@ -24,7 +24,7 @@ This application demonstrates the basic flow to work with SharePoint Embedded co
 * An onboarded application id (sometimes called client id) and its corresponding ContainerTypeId
 * The application client secret, or a client certificate if you want to create application owned containers.
  These can be generated/uploaded in [Azure's Active Directory (AzureAD or AAD) portal](https://portal.azure.com).
-* Visual Studio and/or .Net Framework installed (.NET 6.0 SDK is needed).
+* Visual Studio and/or .Net installed (.NET 8.0 or higher SDK is needed).
 * A ContainerType
 * Having the application registered in the consuming tenant (even if the owner of the application is the same as the consuming)
 * Having the containerType registered in the consuming tenant (even if the owner of the CT is the same as the consuming)

--- a/Samples/asp.net-webservice/appsettings.baseline.json
+++ b/Samples/asp.net-webservice/appsettings.baseline.json
@@ -28,7 +28,7 @@
     "ContainerTypeId": "[ContainerTypeId]"
   },
   "ConnectionStrings": {
-    "AppDBConnStr": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=DemoAppDb;Integrated Security=True;Connect Timeout=30;",
+    "AppDBConnStr": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=DemoAppDb;Integrated Security=True;Connect Timeout=30;"
   },
   "Urls": "https://localhost:57750"
 }


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to update the ASP.NET sample of the app to latest (currently) LTS version of .Net which is .Net 8.

## ✅ What was done 

- [X] Updated project .Net version
- [X] Updated project dependencies to align with latest possible (usually .Net 8) or to update deprecated package
- [X] Small fixup in `appsettings.baseline.json`

## 📸 Result 

Still works 😉 
Some screenshots from the running app 'on my machine' 😛

![image](https://github.com/user-attachments/assets/12de6c72-8c81-4576-853b-013c9aaa5e42)

![image](https://github.com/user-attachments/assets/d87a2341-d2b5-48cf-ace5-853adc7841fc)

## 🔗 Related Issue

Closes #77