### PR TITLE
Fix container enumeration in react sample app

### DIFF
--- a/Samples/spe-typescript-react-azurefunction/common/schemas/ContainerSchemas.ts
+++ b/Samples/spe-typescript-react-azurefunction/common/schemas/ContainerSchemas.ts
@@ -1,9 +1,13 @@
 
+export interface IContainerSettings {
+    isOcrEnabled?: boolean;
+    isItemVersioningEnabled?: boolean;
+    itemMajorVersionLimit?: number;
+}
+
 export interface IContainerClientCreateRequest {
     displayName: string;
     description?: string;
-    itemMajorVersionLimit?: number;
-    isItemVersioningEnabled?: boolean;
 }
 
 export interface IContainerServerCreateRequest extends IContainerClientCreateRequest {
@@ -20,7 +24,7 @@ export interface IContainer extends IContainerUpdateRequest {
     createdDateTime?: string;
     customProperties?: IContainerCustomProperties;
     permissions?: IContainerPermissions;
-    storageUsedInBytes?: number;
+    settings?: IContainerSettings;
     columns: IContainerColumn[];
     drive?: {
         webUrl: string;

--- a/Samples/spe-typescript-react-azurefunction/function-api/src/providers/GraphProvider.ts
+++ b/Samples/spe-typescript-react-azurefunction/function-api/src/providers/GraphProvider.ts
@@ -36,7 +36,6 @@ export class GraphProvider {
     public async listContainers(): Promise<IContainer[]> {
         const response = await this._client
             .api('/storage/fileStorage/containers')
-            .version('beta')
             .filter(`containerTypeId eq ${this._containerTypeId}`)
             .get();
         return response.value as IContainer[];
@@ -56,13 +55,12 @@ export class GraphProvider {
 
     public async getContainer(id: string, loadColumns: boolean = true): Promise<IContainer> {
         const query = { 
-            $select: "id,displayName,containerTypeId,status,createdDateTime,description,customProperties,storageUsedInBytes,itemMajorVersionLimit,isItemVersioningEnabled",
+            $select: "id,displayName,containerTypeId,status,createdDateTime,description,customProperties,settings",
             $expand: "permissions,drive" 
         };
         const response = await this._client
             .api(`/storage/fileStorage/containers/${id}`)
             .query(query)
-            .version('beta')
             .get();
         if (loadColumns) {
             response.columns = await this.getContainerColumns(id);


### PR DESCRIPTION
The react sample app was broken in the function-api because the /containers get call was failing due to a schema change in Graph. Move list and get container Graph calls to use the v1.0 endpoint and adopt updated schema. 