### PR TITLE
fix(validation): launch sample processes via executable shim on Windows

### DIFF
--- a/Tools/powershell/SampleValidation.ps1
+++ b/Tools/powershell/SampleValidation.ps1
@@ -30,12 +30,37 @@ function Resolve-CommandPath {
         return $Name
     }
 
-    $command = Get-Command $Name -ErrorAction Stop
-    if ($null -ne $command.Source -and $command.Source.Length -gt 0) {
-        return $command.Source
+    $commands = @(Get-Command $Name -All -ErrorAction Stop)
+
+    # Start-LoggedProcess launches commands through Start-Process, which (when output is
+    # redirected) uses the OS CreateProcess API. CreateProcess cannot execute PowerShell
+    # script shims (.ps1) and, on Windows, cannot execute the extensionless shell-script
+    # shims that npm/npx ship. Get-Command returns the .ps1 shim first by precedence, so
+    # prefer a directly executable form (.cmd/.exe/...) that both the call operator and
+    # Start-Process can launch.
+    $executableExtensions = @('.exe', '.cmd', '.bat', '.com')
+
+    $preferred = $commands | Where-Object {
+        $_.CommandType -eq 'Application' -and
+        $_.Source -and
+        $executableExtensions -contains [System.IO.Path]::GetExtension($_.Source).ToLowerInvariant()
+    } | Select-Object -First 1
+
+    if ($null -eq $preferred) {
+        # On non-Windows platforms the Application form is typically an extensionless
+        # executable or a shebang script that CreateProcess can exec directly.
+        $preferred = $commands | Where-Object { $_.CommandType -eq 'Application' } | Select-Object -First 1
     }
 
-    return $command.Name
+    if ($null -eq $preferred) {
+        $preferred = $commands | Select-Object -First 1
+    }
+
+    if ($null -ne $preferred.Source -and $preferred.Source.Length -gt 0) {
+        return $preferred.Source
+    }
+
+    return $preferred.Name
 }
 
 function Invoke-ExternalCommand {


### PR DESCRIPTION
## Purpose

This PR targets **`user/dluces/sample_app_test_plan`** (the branch behind #248) so the fix flows into that PR after your review. It fixes a Windows-specific defect in the validation harness added by #248: **every runtime/browser smoke step fails immediately on Windows** with `%1 is not a valid Win32 application`.

## Root cause

`Resolve-CommandPath` (in `Tools/powershell/SampleValidation.ps1`) returned the highest-precedence `Get-Command` match. On Windows, PowerShell command precedence puts the **`.ps1` script shim first** (e.g. `npx.ps1`, `npm.ps1`).

`Start-LoggedProcess` then passes that path to `Start-Process` **with output redirection**, which forces `UseShellExecute = $false` → the OS **`CreateProcess`** API. `CreateProcess` cannot execute PowerShell script shims (`.ps1`) or the extensionless npm/npx shims — hence the failure.

Build/install/test steps are unaffected because they run through `Invoke-ExternalCommand`, which uses the PowerShell call operator (`&`), and that *can* run `.ps1`/`.cmd` shims. Only the `Start-Process`-based launches (long-running servers + browser smoke) break.

**Scope of impact (before this fix):** all Node-based samples that reach the runtime/browser step on Windows — `mcp-server`, `ocr`, both boilerplates' client smokes, `legal-docs`, `project-management`, `webhook`. The ASP.NET sample is unaffected (it launches `dotnet`, a real `.exe`). Non-Windows is unaffected (shebang executables exec directly).

## The change

`Resolve-CommandPath` now prefers a **directly-executable** form (`.exe`/`.cmd`/`.bat`/`.com`) when one exists, so `Start-Process` can launch it. It falls back to the `Application` command form (extensionless / shebang executable) for Linux/macOS, then to the first match. One function changed; no behavior change for the call-operator path.

## Verification (Windows, pwsh 7.4)

- `Resolve-CommandPath` now returns `npx.cmd` / `npm.cmd` / `node.exe` (was `npx.ps1`).
- `Start-LoggedProcess npx --version` (redirected — the exact previously-failing pattern) launches cleanly, **exit 0**, no `%1 is not a valid Win32 application`.
- `Custom Apps/project-management/validate-sample.ps1` now builds → lints (non-blocking) → **starts the preview server (the previously-fatal step)** → passes the HTTP wait → completes, **exit 0**.
- Script parses with no syntax errors.

## Known follow-up (separate issue, intentionally not in this PR)

Once launch works, the full smoke surfaces a distinct **process-teardown** bug: `npx`/`npm` spawn a deep tree (`cmd.exe → node(npx-cli) → node(server)`); `npx-cli` exits and **orphans** the server node, so `Stop-LoggedProcess`'s `Kill($true)` on the wrapper can't reach it and the server lingers on its port. That needs a heavier fix (Windows Job Object with kill-on-close, or PID-tree/port-based teardown) and is kept out of this surgical change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>