### PR TITLE
fix(ocr): sanitize Graph validationToken echo to prevent reflected XSS

### DIFF
--- a/AI/ocr/server/onReceiptAdded.ts
+++ b/AI/ocr/server/onReceiptAdded.ts
@@ -6,10 +6,23 @@ import { ReceiptProcessor } from "./ReceiptProcessor";
 
 require('isomorphic-fetch');
 
+  // Microsoft Graph sends an opaque, URL-safe validationToken when a subscription is
+  // created and expects it echoed back verbatim as text/plain. The value is attacker
+  // influenceable, so strip anything outside the token's known-safe character set
+  // before reflecting it. This is a no-op for legitimate tokens (base64url/base64)
+  // while removing the characters needed for reflected cross-site scripting.
+  const sanitizeValidationToken = (value: unknown): string =>
+    String(value).replace(/[^A-Za-z0-9._~+/=\- ]/g, '');
+
   export const onReceiptAdded = async (req: Request, res: Response) => {
     const validationToken = req.query['validationToken'];
     if (validationToken) {
-      res.status(200).type('text/plain').send(String(validationToken));
+      const safeValidationToken = sanitizeValidationToken(validationToken);
+      res
+        .status(200)
+        .type('text/plain')
+        .set('X-Content-Type-Options', 'nosniff')
+        .send(safeValidationToken);
         return;
     }
 


### PR DESCRIPTION
## Purpose

Fixes the **CodeQL `js/reflected-xss` (high severity)** alert on `#248` — the check currently failing on that PR (`mergeStateStatus: UNSTABLE`). Targets `user/dluces/sample_app_test_plan` so it flows into #248 after review (same pattern as #249).

## The vulnerability

`AI/ocr/server/onReceiptAdded.ts` echoed the Microsoft Graph subscription `validationToken` (from `req.query`) straight into the HTTP response body:

```ts
const validationToken = req.query['validationToken'];
if (validationToken) {
  res.status(200).type('text/plain').send(String(validationToken));   // reflected XSS sink
```

The value is attacker-influenceable and reflected verbatim. Even as `text/plain`, this is a reflected-XSS sink (browser MIME-sniffing, and the value is user-controlled). Introduced when the OCR backend was ported from `restify` to `express` (`b4b864f`).

## The fix

Graph requires the opaque, URL-safe `validationToken` to be echoed back verbatim to complete the subscription handshake, so I **strip any character outside the token's known-safe set** (base64url/base64: `A–Z a–z 0–9 . _ ~ + / = - ` and space) before reflecting it, and add `X-Content-Type-Options: nosniff`:

```ts
const sanitizeValidationToken = (value: unknown): string =>
  String(value).replace(/[^A-Za-z0-9._~+/=\- ]/g, '');
...
res.status(200).type('text/plain').set('X-Content-Type-Options', 'nosniff').send(safeValidationToken);
```

This is a **no-op for legitimate tokens** (so the Graph handshake still works) while removing the characters needed for XSS (`<`, `>`, `"`, etc.).

## Verification (Windows, Node 24)

- `npm run build:backend` compiles clean.
- `validate-sample.ps1` OCR backend smoke passes.
- Live handshake test against the running backend:
  - Legit token `abc123-XYZ_.~token==` → echoed **verbatim** (`MATCH: True`), `Content-Type: text/plain`, `X-Content-Type-Options: nosniff`.
  - `<script>alert(1)</script>` → returned as `scriptalert1/script` (all angle brackets stripped).

CodeQL will re-run on this PR to confirm the alert is resolved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>